### PR TITLE
Correct error in linked guide

### DIFF
--- a/empty/diffdisk.md
+++ b/empty/diffdisk.md
@@ -13,5 +13,6 @@ Things to keep in mind:
 - If the above happens, disable/disconnect all the other disks and install windows as you would normally do
   - For laptops this can be a pain, you can install windows manually by following [this guide from TenForums](https://www.tenforums.com/tutorials/84331-apply-windows-image-using-dism-instead-clean-install.html)
   - Make sure you choose the proper disk
+  - If your Windows install image was made in Mac or Linux, you will have had to split the install.wim file into two .swm files. This means that the command given in the above guide for applying the install.wim image will not work. When the guide tells you to run `dism /Apply-Image` et cetera, instead run `dism /Apply-Image /imagefile:C:\Sources\install.swm /swmfile:C:\Sources\install2.swm /index:1 /ApplyDir:E:\` replacing the drive letters and index with appropriate values.
 - You can still refer to other situations if you want to dualboot more than one OS on one of the disks.
 - Make sure that OpenCore is on the same disk of macOS for easier troubleshooting and cleaner setup

--- a/empty/diffdisk.md
+++ b/empty/diffdisk.md
@@ -13,6 +13,7 @@ Things to keep in mind:
 - If the above happens, disable/disconnect all the other disks and install windows as you would normally do
   - For laptops this can be a pain, you can install windows manually by following [this guide from TenForums](https://www.tenforums.com/tutorials/84331-apply-windows-image-using-dism-instead-clean-install.html)
   - Make sure you choose the proper disk
-  - If your Windows install image was made in Mac or Linux, you will have had to split the install.wim file into two .swm files. This means that the command given in the above guide for applying the install.wim image will not work. When the guide tells you to run `dism /Apply-Image` et cetera, instead run `dism /Apply-Image /imagefile:C:\Sources\install.swm /swmfile:C:\Sources\install2.swm /index:1 /ApplyDir:E:\` replacing the drive letters and index with appropriate values.
+  - If your Windows install image was made in Mac or Linux using FAT32 filesystem, you will have had to split the install.wim file into two .swm files. This means that the command given in the above guide for applying the install.wim image will not work. When the guide tells you to run `dism /Apply-Image` et cetera, instead run `dism /Apply-Image /imagefile:C:\Sources\install.swm /swmfile:C:\Sources\install2.swm /index:1 /ApplyDir:E:\` replacing the drive letters and index with appropriate values.
+  - Alternatively, use exFAT on your install.wim and have OpenCore load the ExFatDxe driver.
 - You can still refer to other situations if you want to dualboot more than one OS on one of the disks.
 - Make sure that OpenCore is on the same disk of macOS for easier troubleshooting and cleaner setup

--- a/empty/diffdisk.md
+++ b/empty/diffdisk.md
@@ -13,7 +13,7 @@ Things to keep in mind:
 - If the above happens, disable/disconnect all the other disks and install windows as you would normally do
   - For laptops this can be a pain, you can install windows manually by following [this guide from TenForums](https://www.tenforums.com/tutorials/84331-apply-windows-image-using-dism-instead-clean-install.html)
   - Make sure you choose the proper disk
-  - If your Windows install image was made in Mac or Linux using FAT32 filesystem, you will have had to split the install.wim file into two .swm files. This means that the command given in the above guide for applying the install.wim image will not work. When the guide tells you to run `dism /Apply-Image` et cetera, instead run `dism /Apply-Image /imagefile:C:\Sources\install.swm /swmfile:C:\Sources\install2.swm /index:1 /ApplyDir:E:\` replacing the drive letters and index with appropriate values.
+  - If your Windows install image was made in Mac or Linux using FAT32 filesystem, you will have had to split the install.wim file into two or more .swm files. This means that the command given in the above guide for applying the install.wim image will not work. When the guide tells you to run `dism /Apply-Image` et cetera, instead run `dism /Apply-Image /imagefile:C:\Sources\install.swm /swmfile:C:\Sources\install*.swm /index:1 /ApplyDir:E:\` replacing the drive letters and index with appropriate values.
   - Alternatively, use exFAT on your install.wim and have OpenCore load the ExFatDxe driver.
 - You can still refer to other situations if you want to dualboot more than one OS on one of the disks.
 - Make sure that OpenCore is on the same disk of macOS for easier troubleshooting and cleaner setup


### PR DESCRIPTION
Because of the need to split the install.wim file when making a Windows ISO drive, the command given in the linked guide requires some correction. The rest of the guide is accurate.